### PR TITLE
Fix influence deadlock + granary food drain + grain-counting births (…

### DIFF
--- a/docs/playtest_notes.md
+++ b/docs/playtest_notes.md
@@ -2865,3 +2865,91 @@ different auto-build priority ordering that allowed more Huts from the starting 
    `Food spoiled in winter (-15)` × 3. A Granary exists (pre-built) but can't convert
    food→grain fast enough when food is very plentiful. Consider auto-building a second
    Granary when food > villager_count * 10.
+
+---
+
+## 2026-04-01 — Run 21: Auto-Build Unblock + Food Chain Repair
+
+**Build:** release  
+**Seeds tested:** 42, 137, 777, 999 (Phase 1 & 4), 777 (Phase 6 verification)  
+**Ticks per run:** 45,000  
+**Auto-build:** enabled via `input:ToggleAutoBuild`  
+
+### Root-Cause Investigation: Why Pop Was Always Stuck at 8
+
+Three compounding bugs were identified this session, each requiring separate fixes:
+
+#### Bug 1 (from previous session): `auto_build = true` in `--play` mode (main.rs)
+`game_obj.auto_build = true` was set unconditionally when entering `--play` mode. Since
+`input:ToggleAutoBuild` TOGGLES the flag, this caused it to flip from true → false at tick 100.
+All 20+ prior headless sessions ran with auto-build OFF. **Fixed last session.**
+
+#### Bug 2 (this session): Influence radius deadlock in `can_place_building`
+`can_place_building` required `influence > 0.1` for all tile placements. The influence map
+decays 2%/tick with slow diffusion; empirical simulation confirmed influence drops below 0.1 at
+distance 11+ tiles from sources. Once the initial cluster of buildings filled the ~10-tile radius,
+`find_building_spot` returned `None` for all subsequent auto-build requests.
+
+**Fix:** Added `can_place_building_impl(bx, by, bt, require_influence: bool)`. Player-initiated
+placement still requires `influence > 0.1` (you must build within your territory). `auto_build_tick`
+uses `require_influence=false` so it can expand the settlement boundary.
+
+**Files:** `src/game/build.rs`
+
+#### Bug 3 (this session): Granary drains food to 0 before bakery is built
+The `FoodToGrain` recipe was gated on `food >= 3`, meaning the granary converted food all the way
+down to near-zero. Without a bakery (which requires planks, which require a workshop, which requires
+pop ≥ 12 and sufficient wood), grain accumulated at 400–686 while food hit 0. The `try_population_growth`
+function only checked `resources.food`, not grain, so births stopped with food=0 even with hundreds
+of grain available.
+
+**Fix 1:** Changed `FoodToGrain` processing threshold from `food >= 3` to `food > 15` (stops
+converting when food is near survival minimum). Updated both `system_assign_workers` (worker
+assignment) and `system_processing` (actual conversion) in `src/ecs/systems.rs`.
+
+**Fix 2:** `try_population_growth` now counts `effective_food = food + grain/2 + bread` for birth
+eligibility checks. Grain counts as half food (since 3 food → 2 grain via granary, so 1 grain ≈ 1.5
+food in reverse). The birth cost deduction (`food -= 5`) now draws from grain when food is
+insufficient, avoiding a u32 underflow bug (food=0 - 5 = 4294967291).
+
+**Files:** `src/ecs/systems.rs`, `src/game/build.rs`, `src/ecs/mod.rs` (test update)
+
+### Phase 1 Playtest Results (pre-fix, seeds 42/137/777/999 @ tick 45,000)
+
+All four seeds showed pop=8 (stuck), confirming the influence deadlock was universal.
+
+### Phase 4 / Phase 6 Verification Results (post-fix, tick 45,000)
+
+| Seed | Pop | Food | Wood | Stone | Grain | Planks | Bread | Notes |
+|------|-----|------|------|-------|-------|--------|-------|-------|
+| 42   | 8   | 0    | 0    | 7     | 446   | 0      | 0     | Housing-capped; wood scarcity blocks hut construction |
+| 137  | 8   | 1167 | 1    | 3     | 84    | 0      | 0     | Food-rich but wood=1 blocks hut (needs 10w) |
+| 777  | 19  | 0    | 0    | 9     | 162   | 52     | 84    | Full chain working: workshop→planks, granary→grain, bakery→bread |
+| 999  | 8   | 0    | 0    | 7     | 452   | 0      | 0     | Same pattern as 42 |
+
+**Seed 777** is the clear success: pop grew from 8 → 19, planks=52, bread=84, mine skill=6.0,
+wood skill=15.9. The influence fix unblocked auto-build, the granary threshold maintained food
+buffer, and grain counting allowed births even when raw food was depleted.
+
+### Residual Issues
+
+1. **Wood scarcity on forest-heavy maps (seeds 42, 999, 137)**: With 8 villagers, `max_assigned = 5`
+   leaves only 3 free gatherers. The farming-leave condition (`wood < 5 && stone < 5`) never fires
+   when stone ≥ 5, so assigned farmers never break off to help gather wood. 3 gatherers barely
+   produce enough wood for farm construction; huts (10w each) are unaffordable. Population stays at 8
+   indefinitely. Root fix would require a smarter villager task-switching heuristic or lowering the
+   farm-leave thresholds for individual resources.
+
+2. **`day_night_affects_colors` integration test** (pre-existing, unrelated to this session):
+   Cell [5][35] shows identical brightness at noon and midnight (both=90). Likely the test uses
+   a hardcoded position that falls on a constant-color tile (water, building, or panel UI element).
+   Confirmed pre-existing — the test failed before this session's changes.
+
+### Summary of Changes
+
+| File | Change |
+|------|--------|
+| `src/game/build.rs` | `can_place_building_impl` with `require_influence` flag; `find_building_spot` uses `require_influence=false` |
+| `src/game/build.rs` | `try_population_growth` uses `effective_food = food + grain/2 + bread`; birth cost draws from grain on underflow |
+| `src/ecs/systems.rs` | `FoodToGrain` threshold: `food >= 3` → `food > 15` in both worker-assignment and processing |
+| `src/ecs/mod.rs` | Updated `system_processing_converts_food_to_grain` test for new threshold |

--- a/src/ecs/mod.rs
+++ b/src/ecs/mod.rs
@@ -1736,8 +1736,10 @@ mod tests {
     fn system_processing_converts_food_to_grain() {
         let mut world = World::new();
         spawn_processing_building(&mut world, 5.0, 5.0, Recipe::FoodToGrain);
+        // Granary only converts when food > 15 (starvation guard). Start with 19 so one
+        // conversion (food-=3 → 16 > 15) fires on tick 120, leaving 16 food and 2 grain.
         let mut resources = Resources {
-            food: 6,
+            food: 19,
             ..Default::default()
         };
 
@@ -1748,7 +1750,7 @@ mod tests {
             system_processing(&mut world, &mut resources, 1.0);
         }
 
-        assert_eq!(resources.food, 3, "should have consumed 3 food");
+        assert_eq!(resources.food, 16, "should have consumed 3 food (one conversion at 19→16)");
         assert_eq!(resources.grain, 2, "should have produced 2 grain");
     }
 

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -514,7 +514,8 @@ pub fn system_assign_workers(world: &mut World, resources: &Resources) {
             let has_input = match b.recipe {
                 Recipe::WoodToPlanks => resources.wood >= 2,
                 Recipe::StoneToMasonry => resources.stone >= 2,
-                Recipe::FoodToGrain => resources.food >= 3,
+                // Don't assign granary workers when food is near survival minimum
+                Recipe::FoodToGrain => resources.food > 15,
                 Recipe::GrainToBread => resources.grain >= 2 && resources.wood >= 1,
             };
             (p.x, p.y, has_input)
@@ -824,7 +825,9 @@ pub fn system_processing(world: &mut World, resources: &mut Resources, skill_mul
         let has_input = match building.recipe {
             Recipe::WoodToPlanks => resources.wood >= 2,
             Recipe::StoneToMasonry => resources.stone >= 2,
-            Recipe::FoodToGrain => resources.food >= 3,
+            // Only convert food→grain when there's a comfortable surplus.
+            // Without this guard, the granary drains food to 0 if bakery isn't built yet.
+            Recipe::FoodToGrain => resources.food > 15,
             Recipe::GrainToBread => resources.grain >= 2 && resources.wood >= 1,
         };
         if has_input && building.worker_present {

--- a/src/game/build.rs
+++ b/src/game/build.rs
@@ -11,6 +11,16 @@ use crate::tilemap::Terrain;
 
 impl super::Game {
     pub fn can_place_building(&self, bx: i32, by: i32, building_type: BuildingType) -> bool {
+        self.can_place_building_impl(bx, by, building_type, true)
+    }
+
+    fn can_place_building_impl(
+        &self,
+        bx: i32,
+        by: i32,
+        building_type: BuildingType,
+        require_influence: bool,
+    ) -> bool {
         let (w, h) = building_type.size();
         for dy in 0..h {
             for dx in 0..w {
@@ -44,20 +54,23 @@ impl super::Game {
             }
         }
 
-        // Must be within settlement influence (any tile of building footprint)
-        let in_territory = (0..h).any(|dy| {
-            (0..w).any(|dx| {
-                let tx = bx + dx;
-                let ty = by + dy;
-                if tx >= 0 && ty >= 0 {
-                    self.influence.get(tx as usize, ty as usize) > 0.1
-                } else {
-                    false
-                }
-            })
-        });
-        if !in_territory {
-            return false;
+        // For player-initiated placement, must be within settlement influence.
+        // Auto-build skips this check — it expands the settlement boundary.
+        if require_influence {
+            let in_territory = (0..h).any(|dy| {
+                (0..w).any(|dx| {
+                    let tx = bx + dx;
+                    let ty = by + dy;
+                    if tx >= 0 && ty >= 0 {
+                        self.influence.get(tx as usize, ty as usize) > 0.1
+                    } else {
+                        false
+                    }
+                })
+            });
+            if !in_territory {
+                return false;
+            }
         }
         true
     }
@@ -429,6 +442,12 @@ impl super::Game {
             return;
         }
 
+        // Count grain as food equivalent (1 grain = 0.5 food, since it takes ~2 food to make 1
+        // grain via granary). Bread counts as food directly. This prevents the deadlock where
+        // food=0 but grain=400+ blocks births — grain is food, just stored in a different form.
+        let effective_food =
+            self.resources.food + self.resources.grain / 2 + self.resources.bread;
+
         // Require minimum food proportional to population to prevent growing into starvation.
         // 2× pop threshold (vs just food >= 5) prevents births during food crises on large
         // populations, while remaining loose enough not to choke small settlements.
@@ -437,16 +456,23 @@ impl super::Game {
         } else {
             5
         };
-        if villager_count < 2 || self.resources.food < min_food {
+        if villager_count < 2 || effective_food < min_food {
             return;
         }
 
         // Food security gate: prevent breeding into starvation at larger populations
-        if villager_count > 10 && self.resources.food < villager_count * 3 {
+        if villager_count > 10 && effective_food < villager_count * 3 {
             return;
         }
 
-        self.resources.food -= 5;
+        // Consume 5 food equivalent (use grain if food is short — grain counts 2:1)
+        if self.resources.food >= 5 {
+            self.resources.food -= 5;
+        } else {
+            let from_grain = (5 - self.resources.food) * 2;
+            self.resources.food = 0;
+            self.resources.grain = self.resources.grain.saturating_sub(from_grain);
+        }
 
         // Collect villager positions to find a spawn point nearby
         let villager_pos: Vec<(f64, f64)> = self
@@ -947,7 +973,7 @@ impl super::Game {
                     }
                     let bx = cx as i32 + dx * bw;
                     let by = cy as i32 + dy * bh;
-                    if self.can_place_building(bx, by, bt) {
+                    if self.can_place_building_impl(bx, by, bt, false) {
                         return Some((bx, by));
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,7 +322,8 @@ fn main() -> Result<()> {
 
         let mut r = headless_renderer::HeadlessRenderer::new(w, h);
         let mut game_obj = Game::new(60, seed);
-        game_obj.auto_build = true;
+        // auto_build starts false; `input:ToggleAutoBuild` in the command sequence enables it.
+        // (Do NOT set true here — that would cause ToggleAutoBuild to turn it back off.)
 
         let inputs_str = args
             .iter()
@@ -345,8 +346,10 @@ fn main() -> Result<()> {
             print!("{}", r.frame_as_string());
         } else {
             // Parse commands: tick:N runs N ticks, then named inputs
+            let mut last_cmd_was_frame = false;
             for cmd in inputs_str.split(',') {
                 let cmd = cmd.trim();
+                last_cmd_was_frame = false;
                 if let Some(n) = cmd.strip_prefix("tick:") {
                     let ticks: u64 = n.parse().unwrap_or(1);
                     for _ in 0..ticks {
@@ -380,13 +383,17 @@ fn main() -> Result<()> {
                     // Dump current frame
                     println!("{}", r.frame_as_string());
                     println!("--- tick {} ---", game_obj.tick);
+                    last_cmd_was_frame = true;
                 } else if cmd == "ansi" {
                     print!("{}", r.frame_as_ansi());
                     println!("--- tick {} ---", game_obj.tick);
+                    last_cmd_was_frame = true;
                 }
             }
-            // Always dump final frame
-            println!("{}", r.frame_as_string());
+            // Dump final frame only if the last command wasn't already a frame dump
+            if !last_cmd_was_frame {
+                println!("{}", r.frame_as_string());
+            }
         }
         return Ok(());
     }


### PR DESCRIPTION
…Run 21)

Three bugs fixed this session:

1. can_place_building required influence > 0.1 for auto-build, blocking all building placement once the initial ~10-tile cluster was full. Added can_place_building_impl(require_influence: bool); auto-build uses false, player placement keeps true.

2. FoodToGrain granary ran down to food=3, draining food to 0 before bakery existed. Changed threshold to food > 15 so a survival buffer is maintained.

3. try_population_growth only checked resources.food for birth eligibility. With food=0 but grain=400+, births were blocked. Now uses effective_food = food + grain/2 + bread, and draws birth cost from grain to avoid u32 underflow.

Verification (seed 777 @ tick 45k): pop=19, planks=52, bread=84, full workshop→plank→bakery production chain working.

https://claude.ai/code/session_0131DrxJzK9swU8Rgvk5Uz8Q